### PR TITLE
Create hash provider

### DIFF
--- a/src/modules/users/providers/HashProvider/implementations/BcryptHashProvider.ts
+++ b/src/modules/users/providers/HashProvider/implementations/BcryptHashProvider.ts
@@ -1,0 +1,14 @@
+import { compare, hash } from "bcryptjs";
+import { IHashProvider } from "../models/IHashProvider";
+
+class BcryptHashprovider implements IHashProvider {
+  public async generateHash(payload: string): Promise<string> {
+    return hash(payload, 8);
+  }
+
+  public async compareHash(payload: string, hashed: string): Promise<boolean> {
+    return compare(payload, hashed);
+  }
+}
+
+export default BcryptHashprovider;

--- a/src/modules/users/providers/HashProvider/index.ts
+++ b/src/modules/users/providers/HashProvider/index.ts
@@ -1,0 +1,6 @@
+// Container de injeção de dependências do BcryptHashprovider
+import { container } from "tsyringe";
+import BcryptHashprovider from "./implementations/BcryptHashProvider";
+import { IHashProvider } from "./models/IHashProvider";
+
+container.registerSingleton<IHashProvider>("HashProvider", BcryptHashprovider);

--- a/src/modules/users/providers/HashProvider/models/IHashProvider.ts
+++ b/src/modules/users/providers/HashProvider/models/IHashProvider.ts
@@ -1,0 +1,4 @@
+export interface IHashProvider {
+  generateHash(payload: string): Promise<string>;
+  compareHash(payload: string, hashed: string): Promise<boolean>;
+}

--- a/src/modules/users/services/CreateUserService.ts
+++ b/src/modules/users/services/CreateUserService.ts
@@ -1,15 +1,18 @@
 import AppError from "@shared/errors/AppError";
-import { hash } from "bcryptjs";
 import { inject, injectable } from "tsyringe";
 import { ICreateUser } from "../domain/models/ICreateUser";
 import { IUser } from "../domain/models/IUser";
 import { IUsersRepository } from "../domain/repositories/IUserRepository";
+import { IHashProvider } from "../providers/HashProvider/models/IHashProvider";
 
 @injectable()
 class CreateUserService {
   constructor(
+    // Injetar dependências
     @inject("UserRepository")
     private userRepository: IUsersRepository,
+    @inject("HashProvider")
+    private hashProvider: IHashProvider,
   ) {}
 
   public async execute({ name, email, password }: ICreateUser): Promise<IUser> {
@@ -19,7 +22,7 @@ class CreateUserService {
       throw new AppError("Email address already used.");
     }
 
-    const hashedPassword = await hash(password, 8);
+    const hashedPassword = await this.hashProvider.generateHash(password);
 
     const user = await this.userRepository.create({
       name,

--- a/src/shared/container/index.ts
+++ b/src/shared/container/index.ts
@@ -1,6 +1,6 @@
 import { IUsersRepository } from "@modules/users/domain/repositories/IUserRepository";
 import UserRepository from "@modules/users/infra/typeorm/repositories/UserRepository";
+import "@modules/users/providers"; // Import do container do HashProvider
 import { container } from "tsyringe";
-
 // Config container para que esteja disponível para injetar nas classes
 container.registerSingleton<IUsersRepository>("UserRepository", UserRepository);


### PR DESCRIPTION
Create provider for the use of bcrypt, thus maintaining the principle of single responsibility